### PR TITLE
fix: fix image clipping out of the container

### DIFF
--- a/lib/shopping.dart
+++ b/lib/shopping.dart
@@ -130,9 +130,12 @@ class _shoppingState extends State<shopping> {
         child: Stack(
           alignment: Alignment.center,
           children: [
-            Image.asset(
-              "${image}",
-              fit: BoxFit.fill,
+            ClipRRect(
+              borderRadius: BorderRadius.circular(10),
+              child: Image.asset(
+                "${image}",
+                fit: BoxFit.fill,
+              ),
             ),
             Align(
               alignment: Alignment.topLeft,


### PR DESCRIPTION
Fixed image clipping out of the container box.

**Before:**
<img width="395" alt="image" src="https://github.com/jeminthesiya/shopping/assets/66340618/da2c1ac5-b9f8-48d6-a1e8-0d3523773b3a">

**After fix:**
<img width="190" alt="image" src="https://github.com/jeminthesiya/shopping/assets/66340618/08a86ac0-d104-46ef-b2cf-4abe70ed15c0">
